### PR TITLE
Add ArrayHydrator

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,6 +27,8 @@
         <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
         <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName" />
         <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn" />
+        <!-- Disabled until bug https://github.com/squizlabs/PHP_CodeSniffer/issues/1471 is resolved -->
+        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber" />
     </rule>
 
     <rule ref="Squiz.Commenting.FunctionComment.Missing">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,6 +29,7 @@
         <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn" />
         <!-- Disabled until bug https://github.com/squizlabs/PHP_CodeSniffer/issues/1471 is resolved -->
         <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber" />
+        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing" />
     </rule>
 
     <rule ref="Squiz.Commenting.FunctionComment.Missing">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,6 +26,7 @@
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
         <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
         <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName" />
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn" />
     </rule>
 
     <rule ref="Squiz.Commenting.FunctionComment.Missing">

--- a/src/Common/Exception.php
+++ b/src/Common/Exception.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common;
+
+/**
+ * Watson SDK Exception.
+ */
+interface Exception
+{
+}

--- a/src/Common/Exception/HydrationException.php
+++ b/src/Common/Exception/HydrationException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common\Exception;
+
+use RuntimeException;
+use IBM\Watson\Common\Exception;
+
+/**
+ * Exception to be thrown during hydration.
+ */
+class HydrationException extends RuntimeException implements Exception
+{
+}

--- a/src/Common/Exception/JsonException.php
+++ b/src/Common/Exception/JsonException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common\Exception;
+
+use IBM\Watson\Common\Exception;
+
+/**
+ * Exception throw when using json native methods.
+ */
+class JsonException extends \Exception implements Exception
+{
+}

--- a/src/Common/Hydrator/AbstractHydrator.php
+++ b/src/Common/Hydrator/AbstractHydrator.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common\Hydrator;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * AbstractHydrator provides common protected methods other hydrators might need to use.
+ */
+abstract class AbstractHydrator implements HydratorInterface
+{
+    const HEADER_CONTENT_TYPE = 'Content-Type';
+
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $response Response to check.
+     *
+     * @return bool
+     *
+     */
+    protected function isJsonResponse(ResponseInterface $response): bool
+    {
+        return 0 === \strpos($response->getHeaderLine(self::HEADER_CONTENT_TYPE), 'application/json');
+    }
+
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $response Response to parse.
+     *
+     * @return string
+     */
+    protected function getBody(ResponseInterface $response): string
+    {
+        return $response->getBody()->__toString();
+    }
+
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $response Response to parse.
+     *
+     * @return array|null
+     */
+    protected function getBodyContent(ResponseInterface $response): ?array
+    {
+        return json_decode($this->getBody($response), true);
+    }
+}

--- a/src/Common/Hydrator/AbstractHydrator.php
+++ b/src/Common/Hydrator/AbstractHydrator.php
@@ -17,7 +17,6 @@ abstract class AbstractHydrator implements HydratorInterface
      * @param \Psr\Http\Message\ResponseInterface $response Response to check.
      *
      * @return bool
-     *
      */
     protected function isJsonResponse(ResponseInterface $response): bool
     {

--- a/src/Common/Hydrator/AbstractHydrator.php
+++ b/src/Common/Hydrator/AbstractHydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace IBM\Watson\Common\Hydrator;
 
+use IBM\Watson\Common\Exception\JsonException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -36,10 +37,22 @@ abstract class AbstractHydrator implements HydratorInterface
     /**
      * @param \Psr\Http\Message\ResponseInterface $response Response to parse.
      *
-     * @return array|null
+     * @return array
+     *
+     * @throws \IBM\Watson\Common\Exception\JsonException
      */
-    protected function getBodyContent(ResponseInterface $response): ?array
+    protected function getBodyContent(ResponseInterface $response): array
     {
-        return json_decode($this->getBody($response), true);
+        $json = json_decode($this->getBody($response), true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new JsonException(sprintf(
+                'Error (%d) when trying to json_decode response: %s',
+                \json_last_error(),
+                \json_last_error_msg()
+            ));
+        }
+
+        return $json;
     }
 }

--- a/src/Common/Hydrator/ArrayHydrator.php
+++ b/src/Common/Hydrator/ArrayHydrator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common\Hydrator;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * The ArrayHydrator will hydrate a json response into an associative array.
+ */
+class ArrayHydrator extends AbstractHydrator
+{
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $response Response to hydrate.
+     * @param string|null                         $class    Class to hydrate to.
+     *
+     * @return array
+     *
+     * @throws \BadMethodCallException
+     */
+    public function hydrate(ResponseInterface $response, string $class = null): array
+    {
+        if (!$this->isJsonResponse($response)) {
+            $message = 'The ArrayHydrator cannot hydrate a response with Content-Type: ';
+            throw new \BadMethodCallException($message.$response->getHeaderLine(self::HEADER_CONTENT_TYPE));
+        }
+
+        $body = $this->getBodyContent($response);
+        if (JSON_ERROR_NONE !== \json_last_error()) {
+            throw new \BadMethodCallException(sprintf(
+                'Error (%d) when trying to json_decode response: %s',
+                \json_last_error(),
+                \json_last_error_msg()
+            ));
+        }
+
+        return $body;
+    }
+}

--- a/src/Common/Hydrator/ArrayHydrator.php
+++ b/src/Common/Hydrator/ArrayHydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace IBM\Watson\Common\Hydrator;
 
+use IBM\Watson\Common\Exception\HydrationException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -17,24 +18,18 @@ class ArrayHydrator extends AbstractHydrator
      *
      * @return array
      *
-     * @throws \BadMethodCallException
+     * @throws \IBM\Watson\Common\Exception\HydrationException
+     * @throws \IBM\Watson\Common\Exception\JsonException
      */
     public function hydrate(ResponseInterface $response, string $class = null): array
     {
         if (!$this->isJsonResponse($response)) {
             $message = 'The ArrayHydrator cannot hydrate a response with Content-Type: ';
 
-            throw new \BadMethodCallException($message.$response->getHeaderLine(self::HEADER_CONTENT_TYPE));
+            throw new HydrationException($message.$response->getHeaderLine(self::HEADER_CONTENT_TYPE));
         }
 
         $body = $this->getBodyContent($response);
-        if (JSON_ERROR_NONE !== \json_last_error()) {
-            throw new \BadMethodCallException(sprintf(
-                'Error (%d) when trying to json_decode response: %s',
-                \json_last_error(),
-                \json_last_error_msg()
-            ));
-        }
 
         return $body;
     }

--- a/src/Common/Hydrator/ArrayHydrator.php
+++ b/src/Common/Hydrator/ArrayHydrator.php
@@ -23,6 +23,7 @@ class ArrayHydrator extends AbstractHydrator
     {
         if (!$this->isJsonResponse($response)) {
             $message = 'The ArrayHydrator cannot hydrate a response with Content-Type: ';
+
             throw new \BadMethodCallException($message.$response->getHeaderLine(self::HEADER_CONTENT_TYPE));
         }
 

--- a/src/Common/Hydrator/HydratorInterface.php
+++ b/src/Common/Hydrator/HydratorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace IBM\Watson\Common\Hydrator;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface HydratorInterface
+{
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $response Response to hydrate.
+     * @param string|null                         $class    Class for hydration.
+     *
+     * @return mixed
+     */
+    public function hydrate(ResponseInterface $response, string $class = null);
+}

--- a/src/Common/Hydrator/ModelHydrator.php
+++ b/src/Common/Hydrator/ModelHydrator.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common\Hydrator;
+
+use IBM\Watson\Common\Model\CreatableFromArray;
+use Psr\Http\Message\ResponseInterface;
+use ReflectionClass;
+
+/**
+ * ModelHydrator will hydrate a ResponseInterface into a model.
+ */
+class ModelHydrator extends AbstractHydrator
+{
+    const METHOD_CREATE = '::create';
+
+    /**
+     * @param \Psr\Http\Message\ResponseInterface $response Response to hydrate.
+     * @param string|null                         $class    Class for hydration.
+     *
+     * @return \IBM\Watson\Common\Model\CreatableFromArray
+     *
+     * @throws \ReflectionException
+     * @throws \BadMethodCallException
+     */
+    public function hydrate(ResponseInterface $response, string $class = null)
+    {
+        if (null === $class) {
+            throw new \BadMethodCallException('The ModelHydrator requires a model class as the second parameter.');
+        }
+
+        if (!$this->isJsonResponse($response)) {
+            $message = 'The ModelHydrator cannot hydrate a response with Content-Type: ';
+
+            throw new \BadMethodCallException($message.$response->getHeaderLine('Content-Type'));
+        }
+
+        $body = $this->getBodyContent($response);
+        if (JSON_ERROR_NONE !== \json_last_error()) {
+            throw new \BadMethodCallException(sprintf(
+                'Error (%d) when trying to json_decode response: %s',
+                \json_last_error(),
+                \json_last_error_msg()
+            ));
+        }
+
+        $reflection = new ReflectionClass($class);
+        if ($reflection->implementsInterface(CreatableFromArray::class)) {
+            $model = \call_user_func($class.self::METHOD_CREATE, $body);
+        } else {
+            $model = new $class($body);
+        }
+
+        return $model;
+    }
+}

--- a/src/Common/Hydrator/ModelHydrator.php
+++ b/src/Common/Hydrator/ModelHydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace IBM\Watson\Common\Hydrator;
 
+use IBM\Watson\Common\Exception\HydrationException;
 use IBM\Watson\Common\Model\CreatableFromArray;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionClass;
@@ -22,28 +23,22 @@ class ModelHydrator extends AbstractHydrator
      * @return \IBM\Watson\Common\Model\CreatableFromArray
      *
      * @throws \ReflectionException
-     * @throws \BadMethodCallException
+     * @throws \IBM\Watson\Common\Exception\HydrationException
+     * @throws \IBM\Watson\Common\Exception\JsonException
      */
     public function hydrate(ResponseInterface $response, string $class = null)
     {
         if (null === $class) {
-            throw new \BadMethodCallException('The ModelHydrator requires a model class as the second parameter.');
+            throw new HydrationException('The ModelHydrator requires a model class as the second parameter.');
         }
 
         if (!$this->isJsonResponse($response)) {
             $message = 'The ModelHydrator cannot hydrate a response with Content-Type: ';
 
-            throw new \BadMethodCallException($message.$response->getHeaderLine('Content-Type'));
+            throw new HydrationException($message.$response->getHeaderLine('Content-Type'));
         }
 
         $body = $this->getBodyContent($response);
-        if (JSON_ERROR_NONE !== \json_last_error()) {
-            throw new \BadMethodCallException(sprintf(
-                'Error (%d) when trying to json_decode response: %s',
-                \json_last_error(),
-                \json_last_error_msg()
-            ));
-        }
 
         $reflection = new ReflectionClass($class);
         if ($reflection->implementsInterface(CreatableFromArray::class)) {

--- a/src/Common/Model/CreatableFromArray.php
+++ b/src/Common/Model/CreatableFromArray.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace IBM\Watson\Common\Model;
+
+/**
+ * Interface for models which can be creted from an array.
+ */
+interface CreatableFromArray
+{
+    /**
+     * @param array $data Data.
+     *
+     * @return \IBM\Watson\Common\Model\CreatableFromArray
+     */
+    public static function create(array $data): self;
+}

--- a/src/Common/Tests/Hydrator/ArrayHydratorTest.php
+++ b/src/Common/Tests/Hydrator/ArrayHydratorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace IBM\Watson\Common\Tests\Hydrator;
+
+use Mockery as m;
+use IBM\Watson\Common\Hydrator\ArrayHydrator;
+use IBM\Watson\Common\Tests\AbstractTestCase;
+use PHPUnit\Framework\Constraint\IsType;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class ArrayHydratorTest extends AbstractTestCase
+{
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @var StreamInterface
+     */
+    private $stream;
+
+    public function setUp()
+    {
+        $this->response = m::mock(ResponseInterface::class);
+        $this->stream = m::mock(StreamInterface::class);
+    }
+
+    public function testHydrate()
+    {
+        $response = $this->getRawMockResponse('SuccessResponse.json');
+        $this->stream
+            ->shouldReceive('__toString')
+            ->once()
+            ->andReturn($response);
+
+        $this->response
+            ->shouldReceive('getHeaderLine')
+            ->once()
+            ->andReturn('application/json');
+
+        $this->response
+            ->shouldReceive('getBody')
+            ->once()
+            ->andReturn($this->stream);
+
+        $hydrator = new ArrayHydrator();
+        $data = $hydrator->hydrate($this->response);
+
+        $this->assertInternalType(IsType::TYPE_ARRAY, $data);
+        $this->assertArrayHasKey('name', $data);
+        $this->assertArrayHasKey('dob', $data);
+        $this->assertArrayHasKey('relationship_status', $data);
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage The ArrayHydrator cannot hydrate a response with Content-Type: text/plain
+     */
+    public function testNoneJsonExceptionIsThrown()
+    {
+        $this->response
+            ->shouldReceive('getHeaderLine')
+            ->once()
+            ->andReturn('text/plain');
+
+        $hydrator = new ArrayHydrator();
+        $hydrator->hydrate($this->response);
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Error (4) when trying to json_decode response: Syntax error
+     */
+    public function testInvalidJsonExceptionIsThrown()
+    {
+        $this->stream
+            ->shouldReceive('__toString')
+            ->once()
+            ->andReturn('{param:value}');
+
+        $this->response
+            ->shouldReceive('getHeaderLine')
+            ->once()
+            ->andReturn('application/json');
+
+        $this->response
+            ->shouldReceive('getBody')
+            ->once()
+            ->andReturn($this->stream);
+
+        $hydrator = new ArrayHydrator();
+        $hydrator->hydrate($this->response);
+    }
+}

--- a/src/Common/Tests/Hydrator/ArrayHydratorTest.php
+++ b/src/Common/Tests/Hydrator/ArrayHydratorTest.php
@@ -55,7 +55,7 @@ class ArrayHydratorTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \BadMethodCallException
+     * @expectedException \IBM\Watson\Common\Exception\HydrationException
      * @expectedExceptionMessage The ArrayHydrator cannot hydrate a response with Content-Type: text/plain
      */
     public function testNoneJsonExceptionIsThrown()
@@ -70,7 +70,7 @@ class ArrayHydratorTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \BadMethodCallException
+     * @expectedException \IBM\Watson\Common\Exception\JsonException
      * @expectedExceptionMessage Error (4) when trying to json_decode response: Syntax error
      */
     public function testInvalidJsonExceptionIsThrown()

--- a/src/Common/Tests/Hydrator/ModelHydratorTest.php
+++ b/src/Common/Tests/Hydrator/ModelHydratorTest.php
@@ -45,7 +45,7 @@ class ModelHydratorTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \BadMethodCallException
+     * @expectedException \IBM\Watson\Common\Exception\HydrationException
      * @expectedExceptionMessage The ModelHydrator requires a model class as the second parameter
      */
     public function testNoModelSuppliedException()
@@ -56,7 +56,7 @@ class ModelHydratorTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \BadMethodCallException
+     * @expectedException \IBM\Watson\Common\Exception\HydrationException
      * @expectedExceptionMessage The ModelHydrator cannot hydrate a response with Content-Type: text/plain
      */
     public function testNoneJsonExceptionIsThrown()
@@ -70,7 +70,7 @@ class ModelHydratorTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \BadMethodCallException
+     * @expectedException \IBM\Watson\Common\Exception\JsonException
      */
     public function testInvalidJsonExceptionIsThrown()
     {

--- a/src/Common/Tests/Hydrator/ModelHydratorTest.php
+++ b/src/Common/Tests/Hydrator/ModelHydratorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace IBM\Watson\Common\Tests\Hydrator;
+
+use IBM\Watson\Common\Hydrator\ModelHydrator;
+use IBM\Watson\Common\stubs\CreatableFromArrayModel;
+use IBM\Watson\Common\stubs\Model;
+use IBM\Watson\Common\Tests\AbstractTestCase;
+use Mockery as m;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class ModelHydratorTest extends AbstractTestCase
+{
+    private $response;
+
+    private $stream;
+
+    private $model;
+
+    private $creatableFromArrayModel;
+
+    public function setUp()
+    {
+        $this->response = m::mock(ResponseInterface::class);
+        $this->stream = m::mock(StreamInterface::class);
+        $this->creatableFromArrayModel = m::mock(CreatableFromArrayModel::class)->makePartial();
+        $this->model = m::mock(Model::class)->makePartial();
+    }
+
+    public function testHydrate()
+    {
+        $this->stream->shouldReceive('__toString')->andReturn('{"param":"value"}');
+
+        $this->response->shouldReceive('getHeaderLine')->once()->andReturn('application/json');
+        $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+
+        $hydrator = new ModelHydrator();
+
+        $content = $hydrator->hydrate($this->response, CreatableFromArrayModel::class);
+        $this->assertInstanceOf(CreatableFromArrayModel::class, $content);
+
+        $content = $hydrator->hydrate($this->response, Model::class);
+        $this->assertInstanceOf(Model::class, $content);
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage The ModelHydrator requires a model class as the second parameter
+     */
+    public function testNoModelSuppliedException()
+    {
+        $hydrator = new ModelHydrator();
+
+        $hydrator->hydrate($this->response);
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage The ModelHydrator cannot hydrate a response with Content-Type: text/plain
+     */
+    public function testNoneJsonExceptionIsThrown()
+    {
+        $this->stream->shouldReceive('__toString')->once()->andReturn('Plain text response');
+        $this->response->shouldReceive('getHeaderLine')->andReturn('text/plain');
+        $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+
+        $hydrator = new ModelHydrator();
+        $hydrator->hydrate($this->response, get_class($this->creatableFromArrayModel));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testInvalidJsonExceptionIsThrown()
+    {
+        $this->stream->shouldReceive('__toString')->once()->andReturn('{param:value}');
+
+        $this->response->shouldReceive('getHeaderLine')->once()->andReturn('application/json');
+        $this->response->shouldReceive('getBody')->once()->andReturn($this->stream);
+
+        $hydrator = new ModelHydrator();
+        $hydrator->hydrate($this->response, get_class($this->creatableFromArrayModel));
+    }
+}

--- a/src/Common/Tests/mock/SuccessResponse.json
+++ b/src/Common/Tests/mock/SuccessResponse.json
@@ -1,0 +1,16 @@
+{
+  "name": "Adam Paterson",
+  "dob": "11/09/1990",
+  "star-sign": "Virgo",
+  "relationship_status": "married",
+  "children": [
+    {
+      "age": 2,
+      "sex": "Female"
+    },
+    {
+      "age": 4,
+      "sex": "Female"
+    }
+  ]
+}

--- a/src/Common/spec/Hydrator/ArrayHydratorSpec.php
+++ b/src/Common/spec/Hydrator/ArrayHydratorSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace spec\IBM\Watson\Common\Hydrator;
+
+use BadMethodCallException;
+use IBM\Watson\Common\Hydrator\ArrayHydrator;
+use IBM\Watson\Common\Hydrator\HydratorInterface;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class ArrayHydratorSpec extends ObjectBehavior
+{
+    public function let(
+        ResponseInterface $response,
+        StreamInterface $stream
+    ) {
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ArrayHydrator::class);
+        $this->shouldHaveType(HydratorInterface::class);
+    }
+
+    public function it_should_throw_exception_when_unable_to_parse_response($response)
+    {
+        $response->getHeaderLine()
+            ->withArguments(['Content-Type'])
+            ->willReturn('text/plain');
+
+        $this->shouldThrow(BadMethodCallException::class)->during('hydrate', [$response]);
+    }
+
+    public function it_should_hydrate_response(StreamInterface $stream, ResponseInterface $response)
+    {
+        $response->getHeaderLine()
+            ->withArguments(['Content-Type'])
+            ->willReturn('application/json');
+
+        $stream->__toString()->willReturn('{"value": "param"}');
+
+        $response->getBody()
+            ->willReturn($stream);
+
+        $this->hydrate($response)->shouldBeArray();
+    }
+}

--- a/src/Common/spec/Hydrator/ArrayHydratorSpec.php
+++ b/src/Common/spec/Hydrator/ArrayHydratorSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\IBM\Watson\Common\Hydrator;
 
-use BadMethodCallException;
+use IBM\Watson\Common\Exception\HydrationException;
 use IBM\Watson\Common\Hydrator\AbstractHydrator;
 use IBM\Watson\Common\Hydrator\ArrayHydrator;
 use IBM\Watson\Common\Hydrator\HydratorInterface;
@@ -31,7 +31,7 @@ class ArrayHydratorSpec extends ObjectBehavior
             ->withArguments(['Content-Type'])
             ->willReturn('text/plain');
 
-        $this->shouldThrow(BadMethodCallException::class)->during('hydrate', [$response]);
+        $this->shouldThrow(HydrationException::class)->during('hydrate', [$response]);
     }
 
     public function it_should_hydrate_response(StreamInterface $stream, ResponseInterface $response)

--- a/src/Common/spec/Hydrator/ModelHydratorSpec.php
+++ b/src/Common/spec/Hydrator/ModelHydratorSpec.php
@@ -2,27 +2,31 @@
 
 namespace spec\IBM\Watson\Common\Hydrator;
 
-use BadMethodCallException;
 use IBM\Watson\Common\Hydrator\AbstractHydrator;
-use IBM\Watson\Common\Hydrator\ArrayHydrator;
 use IBM\Watson\Common\Hydrator\HydratorInterface;
+use IBM\Watson\Common\Hydrator\ModelHydrator;
+use IBM\Watson\Common\Model\CreatableFromArray;
+use IBM\Watson\Common\stubs\CreatableFromArrayModel;
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
-class ArrayHydratorSpec extends ObjectBehavior
+class ModelHydratorSpec extends ObjectBehavior
 {
-    public function let(
-        ResponseInterface $response,
-        StreamInterface $stream
-    ) {
+    public function let(ResponseInterface $response, StreamInterface $stream)
+    {
     }
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType(ArrayHydrator::class);
+        $this->shouldHaveType(ModelHydrator::class);
         $this->shouldHaveType(AbstractHydrator::class);
         $this->shouldHaveType(HydratorInterface::class);
+    }
+
+    public function it_should_thrown_exception_when_class_is_not_provided($response)
+    {
+        $this->shouldThrow(\BadMethodCallException::class)->during('hydrate', [$response]);
     }
 
     public function it_should_throw_exception_when_unable_to_parse_response($response)
@@ -31,7 +35,7 @@ class ArrayHydratorSpec extends ObjectBehavior
             ->withArguments(['Content-Type'])
             ->willReturn('text/plain');
 
-        $this->shouldThrow(BadMethodCallException::class)->during('hydrate', [$response]);
+        $this->shouldThrow(\BadMethodCallException::class)->during('hydrate', [$response]);
     }
 
     public function it_should_hydrate_response(StreamInterface $stream, ResponseInterface $response)
@@ -40,11 +44,11 @@ class ArrayHydratorSpec extends ObjectBehavior
             ->withArguments(['Content-Type'])
             ->willReturn('application/json');
 
-        $stream->__toString()->willReturn('{"value": "param"}');
+        $stream->__toString()->willReturn('{"param": "value"}');
 
         $response->getBody()
             ->willReturn($stream);
 
-        $this->hydrate($response)->shouldBeArray();
+        $this->hydrate($response, CreatableFromArrayModel::class)->shouldReturnAnInstanceOf(CreatableFromArray::class);
     }
 }

--- a/src/Common/spec/Hydrator/ModelHydratorSpec.php
+++ b/src/Common/spec/Hydrator/ModelHydratorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\IBM\Watson\Common\Hydrator;
 
+use IBM\Watson\Common\Exception\HydrationException;
 use IBM\Watson\Common\Hydrator\AbstractHydrator;
 use IBM\Watson\Common\Hydrator\HydratorInterface;
 use IBM\Watson\Common\Hydrator\ModelHydrator;
@@ -26,7 +27,7 @@ class ModelHydratorSpec extends ObjectBehavior
 
     public function it_should_thrown_exception_when_class_is_not_provided($response)
     {
-        $this->shouldThrow(\BadMethodCallException::class)->during('hydrate', [$response]);
+        $this->shouldThrow(HydrationException::class)->during('hydrate', [$response]);
     }
 
     public function it_should_throw_exception_when_unable_to_parse_response($response)
@@ -35,7 +36,7 @@ class ModelHydratorSpec extends ObjectBehavior
             ->withArguments(['Content-Type'])
             ->willReturn('text/plain');
 
-        $this->shouldThrow(\BadMethodCallException::class)->during('hydrate', [$response]);
+        $this->shouldThrow(HydrationException::class)->during('hydrate', [$response]);
     }
 
     public function it_should_hydrate_response(StreamInterface $stream, ResponseInterface $response)

--- a/src/Common/stubs/CreatableFromArrayModel.php
+++ b/src/Common/stubs/CreatableFromArrayModel.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common\stubs;
+
+use IBM\Watson\Common\Model\CreatableFromArray;
+
+/**
+ * Stub class, does nothing.
+ */
+class CreatableFromArrayModel implements CreatableFromArray
+{
+    /**
+     * @var string
+     */
+    private $param;
+
+    /**
+     * CreatableFromArray constructor.
+     *
+     * @param string $param
+     */
+    public function __construct($param)
+    {
+        $this->param = $param;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return \IBM\Watson\Common\Model\CreatableFromArray
+     */
+    public static function create(array $data): CreatableFromArray
+    {
+        return new self($data['param']);
+    }
+
+    /**
+     * @return string
+     */
+    public function getParam(): string
+    {
+        return $this->param;
+    }
+}

--- a/src/Common/stubs/Model.php
+++ b/src/Common/stubs/Model.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IBM\Watson\Common\stubs;
+
+/**
+ * Stub class, does nothing.
+ */
+class Model
+{
+    /**
+     * @var string
+     */
+    private $params;
+
+    /**
+     * @param array $params
+     */
+    public function __construct(array $params)
+    {
+        $this->params = $params;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A

#### What's in this PR?

Hydrator to hydrate `ResponseInterface` instances to an array.


#### Why?

Allows users to interact with responses easier.


#### Example Usage

``` php
$response = new Response(200, [], '{"param": "value"});
$hydrator = new ArrayHydrator();
$array = $hydrator->hydrate($response);

var_dump($array);
```


#### Checklist
- [x] Documentation pull request created (if not simply a bugfix)


#### To Do

- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
